### PR TITLE
Add backup command to create tar.gz archives of server files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,5 +68,10 @@
             <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/schumacher/server/BackupCommand.java
+++ b/src/main/java/de/schumacher/server/BackupCommand.java
@@ -1,0 +1,138 @@
+package de.schumacher.server;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.zip.GZIPOutputStream;
+
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+
+public class BackupCommand implements CommandExecutor {
+
+    private final JavaPlugin plugin; // Referenz zum Plugin für Zugriff auf Serverdaten und Config
+
+    public BackupCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.isOp()) { // Berechtigungsprüfung
+            sender.sendMessage("§cDu hast keine Berechtigung, diesen Befehl auszuführen!");
+            return true;
+        }
+
+        sender.sendMessage("§aBackup wird erstellt, bitte warten...");
+
+        // Konfiguration laden: Backup-Pfad
+        String backupPath = plugin.getConfig().getString("backup.path", "/opt/sicherungen");
+
+        // Zeitstempel für den Dateinamen
+        String timestamp = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
+        File backupFile = new File(backupPath, timestamp + "-Backup-Minecraft.tar.gz");
+
+        try {
+            // Sicherungsordner erstellen, falls nicht vorhanden
+            File backupDir = new File(backupPath);
+            if (!backupDir.exists()) {
+                if (!backupDir.mkdirs()) {
+                    sender.sendMessage("§cFehler: Konnte Sicherungsordner nicht erstellen!");
+                    return true;
+                }
+            }
+
+            // Serververzeichnis abrufen (Minecraft-Root)
+            File serverDir = new File(plugin.getServer().getWorldContainer().getAbsolutePath());
+            File tempDir = new File("temp_backup");
+
+            // Erstellt eine Kopie des Ordners
+            copyDirectory(serverDir, tempDir);
+
+            // Erstelle Backup von der Kopie
+            createTarGz(tempDir, backupFile);
+
+            // Temporäre Dateien löschen
+            deleteDirectory(tempDir);
+
+            sender.sendMessage("§aBackup erfolgreich erstellt: " + backupFile.getAbsolutePath());
+        } catch (Exception e) {
+            sender.sendMessage("§cEin Fehler ist beim Erstellen des Backups aufgetreten: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+    private void copyDirectory(File source, File target) throws IOException {
+        if (!target.exists()) {
+            target.mkdirs();
+        }
+
+        for (File file : source.listFiles()) {
+            File targetFile = new File(target, file.getName());
+            if (file.isDirectory()) {
+                copyDirectory(file, targetFile); // Rekursives Kopieren für Unterordner
+            } else {
+                try (InputStream in = new FileInputStream(file);
+                     OutputStream out = new FileOutputStream(targetFile)) {
+
+                    byte[] buffer = new byte[1024];
+                    int length;
+                    while ((length = in.read(buffer)) > 0) {
+                        out.write(buffer, 0, length);
+                    }
+                }
+            }
+        }
+    }
+    private void createTarGz(File sourceDir, File tarGzFile) throws IOException {
+        // Speichern der Daten auf die Festplatte
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "save-all");
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "save-off");
+        try (FileOutputStream fos = new FileOutputStream(tarGzFile);
+             BufferedOutputStream bos = new BufferedOutputStream(fos);
+             GZIPOutputStream gos = new GZIPOutputStream(bos);
+             TarArchiveOutputStream tos = new TarArchiveOutputStream(gos)) {
+
+            // Normale Datei-Blockgröße setzen, um korrekte Tar-Kompatibilität sicherzustellen
+            tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+
+            // Dateien und Ordner in das tar-Archiv schreiben
+            addFilesToTarGz(sourceDir, "", tos);
+        }finally {
+            // Automatisches Speichern aktivieren
+            plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "save-on");
+        }
+    }
+
+    private void addFilesToTarGz(File file, String parent, TarArchiveOutputStream tos) throws IOException {
+        String entryName = parent + file.getName();
+        TarArchiveEntry entry = new TarArchiveEntry(file, entryName);
+
+        tos.putArchiveEntry(entry);
+
+        if (file.isFile()) {
+            // Datei-Content schreiben
+            try (FileInputStream fis = new FileInputStream(file)) {
+                byte[] buffer = new byte[1024];
+                int length;
+                while ((length = fis.read(buffer)) > 0) {
+                    tos.write(buffer, 0, length);
+                }
+            }
+            tos.closeArchiveEntry();
+        } else if (file.isDirectory()) {
+            tos.closeArchiveEntry();
+            // Rekursiv alle Dateien im Verzeichnis hinzufügen
+            for (File child : file.listFiles()) {
+                addFilesToTarGz(child, entryName + "/", tos);
+            }
+        }
+    }
+}

--- a/src/main/java/de/schumacher/server/Server.java
+++ b/src/main/java/de/schumacher/server/Server.java
@@ -9,6 +9,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 public final class Server extends JavaPlugin {
 
     private MapGenerator mapGenerator;
+    private DebugLogger debugLogger;
+    private ServerPerformanceMonitor serverPerformanceMonitor;
+    private PlayerPositionExporter playerPositionExporter;
+    private InvasionCommand invasionCommand;
+    private ServerStatusCommand serverStatusCommand;
+    private BackupCommand backupCommand;
 
     @Override
     public void onEnable() {
@@ -16,11 +22,12 @@ public final class Server extends JavaPlugin {
         this.saveDefaultConfig();
         // Initialisiere den MapGenerator
         mapGenerator = new MapGenerator(this);
+
         // Initialisiere Performance-Monitor mit Config
         ServerPerformanceMonitor.initialize(this.getConfig());
         // Initialisiere Debugging
         DebugLogger.initialize(this.getConfig());
-
+        getCommand("backup").setExecutor(new BackupCommand(this));
         // Beispiel-Nutzung
         DebugLogger.log("INFO", "Server Plugin wird aktiviert...");
         DebugLogger.log("DEBUG", "Dies ist eine Debug-Nachricht.");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,3 +33,7 @@ invasion:
 debug:
   enabled: false
   log_level: "INFO"
+# Backup
+backup:
+  path: "/opt/sicherungen" # Standard-Speicherort für Sicherungen
+  password: "DeinPasswort123" # Passwort für die Verschlüsselung

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,9 +19,16 @@ commands:
     usage: /serverstatus
     permission: server.serverstatus
     permission-message: You do not have permission!
+  backup:
+    description: Erstellt ein tar.gz-Backup des Minecraft-Ordners.
+    usage: /backup
+    permission: server.backup.create
 permissions:
   server.dynmap:
     description: Erlaubt Generierten der Welt Karte -> html
+    default: op
+  server.backup.create:
+    description: Berechtigung, um Backups zu erstellen.
     default: op
   server.serverstatus:
     description: Erlaubt Zeigt den aktuellen Zustand des Servers an.


### PR DESCRIPTION
Introduces a new `/backup` command to generate compressed backups of the server files. Updates the `plugin.yml` and `config.yml` to configure command behavior and backup paths. Also adds the `Apache Commons Compress` dependency for handling compression.