### PR TITLE
Add embedded Tomcat server for HTTP support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,5 +73,15 @@
             <artifactId>commons-compress</artifactId>
             <version>1.26.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>11.0.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/schumacher/server/EmbeddedTomcatServer.java
+++ b/src/main/java/de/schumacher/server/EmbeddedTomcatServer.java
@@ -1,0 +1,93 @@
+
+
+package de.schumacher.server;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.servlets.DefaultServlet;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.tomcat.util.net.SSLHostConfig;
+import org.apache.tomcat.util.net.SSLHostConfigCertificate;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+
+public class EmbeddedTomcatServer {
+
+    private final int port;
+    private final String webRoot;
+    private Tomcat tomcat;
+    private Thread awaitThread;
+    public EmbeddedTomcatServer(int port, String webRoot) {
+        this.port = port;
+        this.webRoot = webRoot;
+    }
+    public void start() throws Exception {
+        // Tomcat-Instanz erstellen
+        tomcat = new Tomcat();
+        tomcat.setHostname("localhost");
+        tomcat.setPort(port);
+
+        System.out.println("Starting Embedded Tomcat Server on Port " + port + "!");
+
+        // Optional: HTTPS hinzufügen (wenn benötigt)
+        Connector sslConnector = new Connector();
+        sslConnector.setPort(8443); // HTTPS-Port
+        sslConnector.setSecure(true);
+        sslConnector.setScheme("https");
+        tomcat.getService().addConnector(sslConnector);
+
+        // WebRoot-Verzeichnis überprüfen
+        File root = new File(webRoot).getAbsoluteFile();
+        if (!root.exists()) {
+            throw new IllegalArgumentException("WebRoot-Verzeichnis existiert nicht: " + root.getAbsolutePath());
+        }
+
+        // Context hinzufügen
+        Context context = tomcat.addContext("", webRoot);
+
+        // Default-Servlet für statische Dateien
+        context.addWelcomeFile("index.html");
+        tomcat.addServlet("", "default", new DefaultServlet());
+        context.addServletMappingDecoded("/", "default");
+
+        // Tomcat starten
+        tomcat.start();
+        System.out.println("Tomcat gestartet auf Port " + port);
+
+        // Thread für Tomcat await
+        awaitThread = new Thread(() -> tomcat.getServer().await());
+        awaitThread.setDaemon(true);
+        awaitThread.start();
+    }
+
+    public void stop() {
+        if (tomcat != null) {
+            try {
+                // Beende Tomcat blockierend
+                tomcat.stop();
+                tomcat.destroy();
+                System.out.println("Tomcat wurde erfolgreich gestoppt.");
+            } catch (LifecycleException e) {
+                System.err.println("Fehler beim Stoppen des Tomcat-Servers:");
+                e.printStackTrace();
+            }
+        }
+
+        if (awaitThread != null && awaitThread.isAlive()) {
+            // Unterbreche den blockierenden Thread
+            awaitThread.interrupt();
+        }
+    }
+
+}
+
+
+
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,6 +33,11 @@ invasion:
 debug:
   enabled: false
   log_level: "INFO"
+# Allgemeine Tomcat-Einstellungen
+tomcat:
+  enabled: true               # Ob der Tomcat-Server gestartet werden soll
+  http_port: 8080             # HTTP-Port des Tomcat-Servers
+  https_port: 8443            # HTTPS-Port des Tomcat-Servers
 # Backup
 backup:
   path: "/opt/sicherungen" # Standard-Speicherort für Sicherungen


### PR DESCRIPTION
Integrated an embedded Tomcat server with configurable ports via `config.yml` for HTTP. Added handling for starting and stopping the server in the plugin lifecycle. Warns users that the embedded server is not suitable for production environments.